### PR TITLE
Add MQTT location response tests

### DIFF
--- a/KiaTests/VehicleMQTTLocationResponseTests.swift
+++ b/KiaTests/VehicleMQTTLocationResponseTests.swift
@@ -1,0 +1,70 @@
+//
+//  VehicleMQTTLocationResponseTests.swift
+//  KiaTests
+//
+//  Created by Codex on 03/03/26.
+//
+
+import XCTest
+@testable import KiaMaps
+
+final class VehicleMQTTLocationResponseTests: XCTestCase {
+
+    func testDecode_ValidMergedTimestampWithNullLocation() throws {
+        let data = Data(
+            """
+            {
+              "latestUpdateTime": "20250901142733",
+              "state": {
+                "Vehicle": {
+                  "Location": null
+                }
+              }
+            }
+            """.utf8
+        )
+
+        let response = try JSONDecoder().decode(VehicleMQTTLocationResponse.self, from: data)
+        XCTAssertNil(response.state.vehicle.location)
+
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        let components = utc.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: response.lastUpdateTime
+        )
+
+        XCTAssertEqual(components.year, 2025)
+        XCTAssertEqual(components.month, 9)
+        XCTAssertEqual(components.day, 1)
+        XCTAssertEqual(components.hour, 14)
+        XCTAssertEqual(components.minute, 27)
+        XCTAssertEqual(components.second, 33)
+    }
+
+    func testDecode_InvalidMergedTimestamp_Throws() {
+        let data = Data(
+            """
+            {
+              "latestUpdateTime": "2025-09-01T14:27:33Z",
+              "state": {
+                "Vehicle": {
+                  "Location": null
+                }
+              }
+            }
+            """.utf8
+        )
+
+        XCTAssertThrowsError(try JSONDecoder().decode(VehicleMQTTLocationResponse.self, from: data))
+    }
+
+    func testMergedDateFormatter_RoundTrip() {
+        let formatter = MergedDateFormatter()
+        let source = "20241231235958"
+
+        let date = formatter.date(from: source)
+        XCTAssertNotNil(date)
+        XCTAssertEqual(formatter.string(from: date!), source)
+    }
+}

--- a/KiaTests/VehicleMQTTLocationResponseTests.swift
+++ b/KiaTests/VehicleMQTTLocationResponseTests.swift
@@ -27,8 +27,12 @@ final class VehicleMQTTLocationResponseTests: XCTestCase {
         let response = try JSONDecoder().decode(VehicleMQTTLocationResponse.self, from: data)
         XCTAssertNil(response.state.vehicle.location)
 
+        guard let utcTimeZone = TimeZone(secondsFromGMT: 0) else {
+            XCTFail("Failed to create UTC timezone")
+            return
+        }
         var utc = Calendar(identifier: .gregorian)
-        utc.timeZone = TimeZone(secondsFromGMT: 0)!
+        utc.timeZone = utcTimeZone
         let components = utc.dateComponents(
             [.year, .month, .day, .hour, .minute, .second],
             from: response.lastUpdateTime
@@ -56,15 +60,24 @@ final class VehicleMQTTLocationResponseTests: XCTestCase {
             """.utf8
         )
 
-        XCTAssertThrowsError(try JSONDecoder().decode(VehicleMQTTLocationResponse.self, from: data))
+        XCTAssertThrowsError(try JSONDecoder().decode(VehicleMQTTLocationResponse.self, from: data)) { error in
+            guard let parsingError = error as? DateValue<MergedDateFormatter>.ParsingError else {
+                XCTFail("Unexpected error type: \(type(of: error))")
+                return
+            }
+
+            switch parsingError {
+            case .invalidString(let invalidValue, _):
+                XCTAssertEqual(invalidValue, "2025-09-01T14:27:33Z")
+            }
+        }
     }
 
     func testMergedDateFormatter_RoundTrip() {
         let formatter = MergedDateFormatter()
         let source = "20241231235958"
 
-        let date = formatter.date(from: source)
-        XCTAssertNotNil(date)
-        XCTAssertEqual(formatter.string(from: date!), source)
+        let date = try XCTUnwrap(formatter.date(from: source))
+        XCTAssertEqual(formatter.string(from: date), source)
     }
 }


### PR DESCRIPTION
Summary
- add `VehicleMQTTLocationResponseTests` to cover merged timestamp decoding
- verify valid timestamp parsing yields expected UTC components even when location is null
- ensure invalid timestamp formats throw and round-trip formatter via `MergedDateFormatter`

Testing
- Not run (not requested)