### PR TITLE
test: add coverage for mqtt/status date parsing

### DIFF
--- a/KiaTests/MockVehicleDataTests.swift
+++ b/KiaTests/MockVehicleDataTests.swift
@@ -356,4 +356,63 @@ final class MockVehicleDataTests: XCTestCase {
             _ = try? decoder.decode(VehicleState.self, from: jsonData)
         }
     }
+
+    // MARK: - Date Parsing Coverage for Recent MQTT/Status Changes
+
+    func testTimeIntervalDateFormatterDecodesMillisecondsTimestampString() throws {
+        struct TimestampPayload: Codable {
+            @DateValue<TimeIntervalDateFormatter> var ts: Date
+        }
+
+        let json = #"{"ts":"1753344063251"}"#
+        let payload = try JSONDecoder().decode(TimestampPayload.self, from: Data(json.utf8))
+
+        XCTAssertEqual(payload.ts.timeIntervalSince1970, 1_753_344_063.251, accuracy: 0.0001)
+    }
+
+    func testMergedDateFormatterDecodesCompactTimestampString() throws {
+        struct MergedPayload: Codable {
+            @DateValue<MergedDateFormatter> var latestUpdateTime: Date
+        }
+
+        let json = #"{"latestUpdateTime":"20250901202513"}"#
+        let payload = try JSONDecoder().decode(MergedPayload.self, from: Data(json.utf8))
+
+        var components = DateComponents()
+        components.year = 2025
+        components.month = 9
+        components.day = 1
+        components.hour = 20
+        components.minute = 25
+        components.second = 13
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        let expected = Calendar(identifier: .gregorian).date(from: components)
+
+        XCTAssertEqual(payload.latestUpdateTime, expected)
+    }
+
+    func testVehicleMQTTStatusResponseDecodesLatestUpdateTimeAndState() throws {
+        let vehicleJSON = MockVehicleData.createVehicleStateJSON(
+            batteryLevel: 61,
+            isCharging: false,
+            drivingReady: true,
+            scenario: "mqtt_decode"
+        )
+        let mqttJSON = """
+        {
+            "latestUpdateTime": "20250901202513",
+            "state": {
+                "Vehicle": \(vehicleJSON)
+            }
+        }
+        """
+
+        let response = try JSONDecoder().decode(
+            VehicleMQTTStatusResponse.self,
+            from: Data(mqttJSON.utf8)
+        )
+
+        XCTAssertEqual(response.state.vehicle.green.batteryManagement.batteryRemain.ratio, 61)
+        XCTAssertTrue(response.state.vehicle.drivingReady)
+    }
 }


### PR DESCRIPTION
## Summary
- add focused tests for millisecond timestamp parsing via `DateValue<TimeIntervalDateFormatter>`
- add focused tests for compact merged timestamp parsing via `DateValue<MergedDateFormatter>`
- add decode coverage for `VehicleMQTTStatusResponse.latestUpdateTime` + state mapping

## Why
Recent MQTT/status integration changed timestamp handling paths without direct tests.

## Verification
- Added 3 focused XCTest cases in `KiaTests/MockVehicleDataTests.swift`
- Full test run blocked in this environment previously by package/network constraints